### PR TITLE
Get away from master-slave phrasing

### DIFF
--- a/pox/datapaths/nx_switch.py
+++ b/pox/datapaths/nx_switch.py
@@ -18,7 +18,7 @@ import pox.openflow.libopenflow_01 as of
 import pox.openflow.nicira_ext as nx
 from pox.datapaths.switch import SoftwareSwitch, OFConnection
 
-_slave_blacklist = set([of.ofp_flow_mod, of.ofp_packet_out, of.ofp_port_mod,
+_subordinate_blacklist = set([of.ofp_flow_mod, of.ofp_packet_out, of.ofp_port_mod,
                         of.ofp_barrier_request])
 _messages_for_all = set([of.ofp_port_status])
 
@@ -35,17 +35,17 @@ class NXSoftwareSwitch (SoftwareSwitch):
 
   In the beginning, all controllers start out as equals (ROLE_OTHER). Through
   the NX vendor message role_request, one controller can be promoted to
-  ROLE_MASTER, in which case all other controllers are downgraded to slave
+  ROLE_MASTER, in which case all other controllers are downgraded to subordinate
   status.
 
   The switch doesn't accept state-mutating messages (e.g., FLOW_MOD, see
-  _slave_blacklist) from slave controllers.
+  _subordinate_blacklist) from subordinate controllers.
 
   Messages are distributed to controllers according to their type:
     - symmetric message replies are sent to the controller that initiated them
       (e.g., STATS_REQUEST -> REPLY)
     - port_status messages are distributed to all controllers
-    - all other messages are distributed to the master controller, or if none
+    - all other messages are distributed to the main controller, or if none
       is present, any controller in ROLE_OTHER
   """
 
@@ -71,7 +71,7 @@ class NXSoftwareSwitch (SoftwareSwitch):
 
     self.connection_in_action = connection
     if not self.check_rights(msg, connection):
-      self.log.warn("Message %s not allowed for slave controller %d", msg,
+      self.log.warn("Message %s not allowed for subordinate controller %d", msg,
                     connection.ID)
       self.send_vendor_error(connection)
     else:
@@ -83,7 +83,7 @@ class NXSoftwareSwitch (SoftwareSwitch):
     if self.role_by_conn[connection.ID] != nx.ROLE_SLAVE:
       return True
     else:
-      return not type(ofp) in _slave_blacklist
+      return not type(ofp) in _subordinate_blacklist
 
   def send_vendor_error (self, connection):
     err = of.ofp_error(type=of.OFPET_BAD_REQUEST, code=of.OFPBRC_BAD_VENDOR)
@@ -101,11 +101,11 @@ class NXSoftwareSwitch (SoftwareSwitch):
       self.connection_in_action.send(message)
       connections_used.append(self.connection_in_action)
     else:
-      masters = [c for c in self.connections
+      mains = [c for c in self.connections
                  if self.role_by_conn[c.ID] == nx.ROLE_MASTER]
-      if len(masters) > 0:
-        masters[0].send(message)
-        connections_used.append(masters[0])
+      if len(mains) > 0:
+        mains[0].send(message)
+        connections_used.append(mains[0])
       else:
         others = [c for c in self.connections
                   if self.role_by_conn[c.ID] == nx.ROLE_OTHER]

--- a/pox/openflow/nicira.py
+++ b/pox/openflow/nicira.py
@@ -476,9 +476,9 @@ NX_ROLE_SLAVE = 2
 
 class nx_role_request (nicira_base):
   """
-  Requests master/slave/other role type
+  Requests main/subordinate/other role type
 
-  Can initialize with role=NX_ROLE_x or with, e.g., master=True.
+  Can initialize with role=NX_ROLE_x or with, e.g., main=True.
   """
   subtype = NXT_ROLE_REQUEST
   _MIN_LENGTH = 16 + 4
@@ -488,16 +488,16 @@ class nx_role_request (nicira_base):
 
     if kw.pop("other", False):
       self.role = NX_ROLE_OTHER
-    if kw.pop("master", False):
+    if kw.pop("main", False):
       self.role = NX_ROLE_MASTER
-    if kw.pop("slave", False):
+    if kw.pop("subordinate", False):
       self.role = NX_ROLE_SLAVE
 
   @property
-  def master (self):
+  def main (self):
     return self.role == NX_ROLE_MASTER
   @property
-  def slave (self):
+  def subordinate (self):
     return self.role == NX_ROLE_SLAVE
   @property
   def other (self):
@@ -531,8 +531,8 @@ class nx_role_request (nicira_base):
     Format additional fields as text
     """
     s = prefix + "role: "
-    s += {NX_ROLE_OTHER:"other",NX_ROLE_MASTER:"master",
-        NX_ROLE_SLAVE:"slave"}.get(self.role, str(self.role))
+    s += {NX_ROLE_OTHER:"other",NX_ROLE_MASTER:"main",
+        NX_ROLE_SLAVE:"subordinate"}.get(self.role, str(self.role))
     return s + "\n"
 
 class nx_role_reply (nx_role_request):
@@ -2084,27 +2084,27 @@ class nx_async_config (nicira_base):
   subtype = NXT_SET_ASYNC_CONFIG
   _MIN_LENGTH = 40
   def _init (self, kw):
-    # For master or other role
+    # For main or other role
     self.packet_in_mask = 0
     self.port_status_mask = 0
     self.flow_removed_mask = 0
 
-    # For slave role
-    self.packet_in_mask_slave = 0
-    self.port_status_mask_slave = 0
-    self.flow_removed_mask_slave = 0
+    # For subordinate role
+    self.packet_in_mask_subordinate = 0
+    self.port_status_mask_subordinate = 0
+    self.flow_removed_mask_subordinate = 0
 
-  def set_packet_in (self, bit, master=True, slave=True):
-    if master: self.packet_in_mask |= bit
-    if slave: self.packet_in_mask_slave |= bit
+  def set_packet_in (self, bit, main=True, subordinate=True):
+    if main: self.packet_in_mask |= bit
+    if subordinate: self.packet_in_mask_subordinate |= bit
 
-  def set_port_status (self, bit, master=True, slave=True):
-    if master: self.port_status_mask |= bit
-    if slave: self.port_status_mask_slave |= bit
+  def set_port_status (self, bit, main=True, subordinate=True):
+    if main: self.port_status_mask |= bit
+    if subordinate: self.port_status_mask_subordinate |= bit
 
-  def set_flow_removed (self, bit, master=True, slave=True):
-    if master: selfflow_removed_mask |= bit
-    if slave: self.flow_removed_mask_slave |= bit
+  def set_flow_removed (self, bit, main=True, subordinate=True):
+    if main: selfflow_removed_mask |= bit
+    if subordinate: self.flow_removed_mask_subordinate |= bit
 
   def _eq (self, other):
     """
@@ -2115,15 +2115,15 @@ class nx_async_config (nicira_base):
     for a in "packet_in port_status flow_removed".split():
       a += "_mask"
       if getattr(self, a) != getattr(other, a): return False
-      a += "_slave"
+      a += "_subordinate"
       if getattr(self, a) != getattr(other, a): return False
     return True
 
   def _pack_body (self):
     return struct.pack("!IIIIII",
-        self.packet_in_mask, self.packet_in_mask_slave,
-        self.port_status_mask, self.port_status_mask_slave,
-        self.flow_removed_mask, self.flow_removed_mask_slave)
+        self.packet_in_mask, self.packet_in_mask_subordinate,
+        self.port_status_mask, self.port_status_mask_subordinate,
+        self.flow_removed_mask, self.flow_removed_mask_subordinate)
 
   def _unpack_body (self, raw, offset, avail):
     """
@@ -2133,11 +2133,11 @@ class nx_async_config (nicira_base):
     """
     offset,tmp = of._unpack("!IIIIII", raw, offset)
     self.packet_in_mask          = tmp[0]
-    self.packet_in_mask_slave    = tmp[1]
+    self.packet_in_mask_subordinate    = tmp[1]
     self.port_status_mask        = tmp[2]
-    self.port_status_mask_slave  = tmp[3]
+    self.port_status_mask_subordinate  = tmp[3]
     self.flow_removed_mask       = tmp[4]
-    self.flow_removed_mask_slave = tmp[5]
+    self.flow_removed_mask_subordinate = tmp[5]
 
     return offset
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.